### PR TITLE
Use a non-mounted directory for nodejs data

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # Update the VARIANT arg in docker-compose.yml to pick a Node version: 10, 12, 14
 ARG VARIANT=12
 
-FROM quay.io/estuary/flow:v0.1.0-67-g5744a32
+FROM quay.io/estuary/flow:v0.1.0-68-gf1b7159
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 
 # Copy in Estuary Flow release binaries.
@@ -27,3 +27,6 @@ RUN apt-get update \
         python3-pip \
         python3-setuptools \
     && pip3 install -r /usr/local/etcd/flow-doc-requirements.txt
+
+RUN mkdir -p /var/lib/flow
+ENV FLOW_NODEJS_DIR=/var/lib/flow/nodejs


### PR DESCRIPTION
Set the FLOW_NODEJS_DIR variable in the docker image so that it doesn't
use a directory under /workspace. Since /workspace is mounted,
reading/writing files there is very slow on mac, where they need to be
synced between the OSX host and the linux VM. This made nodejs builds
extremely slow, and moving it seems to cut roughly a minute off of full
build times.